### PR TITLE
feat: Support elasticache controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Examples codified under the [`examples`](https://github.com/aws-ia/terraform-aws
 |------|--------|---------|
 | <a name="module_apigatewayv2"></a> [apigatewayv2](#module\_apigatewayv2) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
 | <a name="module_dynamodb"></a> [dynamodb](#module\_dynamodb) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
+| <a name="module_elasticache"></a> [elasticache](#module\_elasticache) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
 | <a name="module_emrcontainers"></a> [emrcontainers](#module\_emrcontainers) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
 | <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
 | <a name="module_prometheusservice"></a> [prometheusservice](#module\_prometheusservice) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
@@ -92,9 +93,11 @@ Examples codified under the [`examples`](https://github.com/aws-ia/terraform-aws
 | <a name="input_dynamodb"></a> [dynamodb](#input\_dynamodb) | ACK dynamodb Helm Chart config | `any` | `{}` | no |
 | <a name="input_ecrpublic_token"></a> [ecrpublic\_token](#input\_ecrpublic\_token) | Password decoded from the authorization token for accessing public ECR | `string` | `""` | no |
 | <a name="input_ecrpublic_username"></a> [ecrpublic\_username](#input\_ecrpublic\_username) | User name decoded from the authorization token for accessing public ECR | `string` | `""` | no |
+| <a name="input_elasticache"></a> [elasticache](#input\_elasticache) | ACK elasticache Helm Chart config | `any` | `{}` | no |
 | <a name="input_emrcontainers"></a> [emrcontainers](#input\_emrcontainers) | ACK EMR container Helm Chart config | `any` | `{}` | no |
 | <a name="input_enable_apigatewayv2"></a> [enable\_apigatewayv2](#input\_enable\_apigatewayv2) | Enable ACK API gateway v2 add-on | `bool` | `false` | no |
 | <a name="input_enable_dynamodb"></a> [enable\_dynamodb](#input\_enable\_dynamodb) | Enable ACK dynamodb add-on | `bool` | `false` | no |
+| <a name="input_enable_elasticache"></a> [enable\_elasticache](#input\_enable\_elasticache) | Enable ACK elasticache add-on | `bool` | `false` | no |
 | <a name="input_enable_emrcontainers"></a> [enable\_emrcontainers](#input\_enable\_emrcontainers) | Enable ACK EMR container add-on | `bool` | `false` | no |
 | <a name="input_enable_eventbridge"></a> [enable\_eventbridge](#input\_enable\_eventbridge) | Enable ACK EventBridge add-on | `bool` | `false` | no |
 | <a name="input_enable_prometheusservice"></a> [enable\_prometheusservice](#input\_enable\_prometheusservice) | Enable ACK prometheusservice add-on | `bool` | `false` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -6,6 +6,7 @@ Configuration in this directory creates an AWS EKS cluster with the following AC
 - ACK DynamoDB controller
 - ACK RDS controller
 - ACK S3 controller
+- ACK Elasticache controller
 
 In addition, this example provisions a sample application which demonstrates using the ACK controllers for resource provisioning.
 The arhchitecture looks like this: <br>
@@ -48,6 +49,7 @@ kubectl get pods -A
 NAMESPACE         NAME                                            READY   STATUS    RESTARTS   AGE
 ack-api-gateway   ack-api-gateway-75499bfcfd-d5627                1/1     Running   0          26s
 ack-dynamodb      ack-dynamodb-76fdf5cf77-jpwd9                   1/1     Running   0          26s
+ack-elasticache   ack-elasticache-45eeg7dv12-m5asf                1/1     Running   0          26s
 ack-rds           ack-rds-85c7ccdbf6-tkpvz                        1/1     Running   0          26s
 ack-s3            ack-s3-7f4c79cbc8-g4tgl                         1/1     Running   0          26s
 kube-system       aws-load-balancer-controller-596d8cb765-wwmzt   1/1     Running   0          26s

--- a/examples/complete/sample-app/elasticache.yaml
+++ b/examples/complete/sample-app/elasticache.yaml
@@ -1,0 +1,82 @@
+---
+# https://aws-controllers-k8s.github.io/community/reference/elasticache/v1alpha1/cacheparametergroup/
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: CacheParameterGroup
+metadata:
+  name: # cache parameter group name
+spec:
+  cacheParameterGroupName: # cache parameter group name
+  cacheParameterGroupFamily: # cache parameter group family
+  description: # cache parameter group description
+  parameterNameValues:
+  # below is an example
+    - parameterName: "TIMEOUT" # parameter name
+      parameterValue: "100" # parameter value
+    # Add more parameter name and value pairs as needed
+
+---
+
+# https://aws-controllers-k8s.github.io/community/reference/ec2/v1alpha1/securitygroup/
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: # security group name
+spec:
+  description: # security group description
+  ingressRules:
+    - fromPort: 6379 # allow redis port
+      toPort: 6379 # allow redis port
+      ipProtocol: tcp
+      ipRanges:
+        - cidrIP: # allow traffic from the same VPC ...
+          description:
+  egressRules:
+    - fromPort: 0
+      toPort: 65535
+      ipProtocol: tcp
+---
+
+# https://aws-controllers-k8s.github.io/community/reference/elasticache/v1alpha1/cachesubnetgroup/
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: CacheSubnetGroup
+metadata:
+  name: # cache subnet group name
+spec:
+  cacheSubnetGroupName: # cache subnet group name
+  cacheSubnetGroupDescription: # cache subnet group description
+  description: # cache subnet group description
+  subnetIDs:
+    - # subnet ID 1
+    - # subnet ID 2
+    - # subnet ID 3
+    # Add more subnet IDs as needed
+
+---
+
+# https://aws-controllers-k8s.github.io/community/reference/elasticache/v1alpha1/replicationgroup/
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: # resource name
+spec:
+  engine: redis
+  engineVersion: 7.1 # or 6.x, check https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html
+  replicationGroupID: # replication group id
+  replicationGroupDescription: # replication group description
+  automaticFailoverEnabled: true # or false
+  cacheNodeType: cache.t2.micro # check https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html
+  numNodeGroups: 1 # depending on your usage
+  replicasPerNodeGroup: 1 # depending on your usage
+  multiAZEnabled: false # or true
+  atRestEncryptionEnabled: false # or true
+  port: 6379 # or 6379
+  snapshotRetentionLimit: 0 # or any number
+  cacheParameterGroupRef:
+    from:
+      name: # cache parameter group name
+  cacheSubnetGroupRef:
+    from:
+      name: # cache subnet group name
+  securityGroupRefs:
+    from:
+      name: # security group name

--- a/outputs.tf
+++ b/outputs.tf
@@ -58,6 +58,12 @@ output "gitops_metadata" {
       namespace       = try(var.eventbridge.namespace, local.eventbridge_name)
       service_account = local.eventbridge_name
       } : "ack_eventbridge_${k}" => v if var.enable_eventbridge
+    },
+    { for k, v in {
+      iam_role_arn    = module.elasticache.iam_role_arn
+      namespace       = try(var.elasticache.namespace, local.elasticache_name)
+      service_account = local.elasticache_name
+      } : "ack_elasticache_${k}" => v if var.enable_elasticache
     }
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,22 @@ variable "s3" {
 }
 
 ################################################################################
+# S3
+################################################################################
+
+variable "enable_elasticache" {
+  description = "Enable ACK elasticache add-on"
+  type        = bool
+  default     = false
+}
+
+variable "elasticache" {
+  description = "ACK elasticache Helm Chart config"
+  type        = any
+  default     = {}
+}
+
+################################################################################
 # RDS
 ################################################################################
 


### PR DESCRIPTION
### What does this PR do?


Continuing the effort of https://github.com/aws-ia/terraform-aws-eks-ack-addons/pull/49, I am adding some feedbacks that maintainers gave on that PR while still keeping @sharkymcdongles credits 

This PR supports  elasticache ack-controller  to close #48 

<!-- A brief description of the change being made with this pull request. -->

### Motivation

- Resolves https://github.com/aws-ia/terraform-aws-eks-ack-addons/issues/48

### Test Results

Please view https://github.com/aws-ia/terraform-aws-eks-ack-addons/pull/49

<!-- Please provide supporting evidence and steps taking to test and validation this change -->

### Additional Notes

I added a dummy example to examples/complete. Reasons for that include:
1. I cannot access https://github.com/season1946/ack-microservices/tree/main/sample-app-code to view the code and know if that service uses elasticache 
2. I dont have the source of `terraform-aws-eks-ack-addons/examples/complete/images/ACK_microservice.png`, so I dont think it's appropriate for outside collaborators to contribute to the example with app integration 
<!-- Anything else we should know when reviewing? -->
